### PR TITLE
Add python2 package for Rocky/Alma 8

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,8 +3,8 @@
 ## Supported distribution
 
 - Centos 7
-- Rocky 8.6+, 9
-- Alma[^alma] 8, 9
+- Rocky 8.6+
+- Alma[^alma] 8
 
 [^alma]: Alma does not provide `openldap-servers` package so it is not supported for host in `[kdc]` Ansible group.
 

--- a/roles/system/defaults/main.yml
+++ b/roles/system/defaults/main.yml
@@ -27,4 +27,5 @@ default_packages:
     - python2-setuptools
     - python2-cryptography
   modern: # centos 8 and above
+    - python2
     - python3-cryptography


### PR DESCRIPTION
Python 2 is not available for Redhat 9 so Rocky 9 and Alma 9 are not supported.

<!--  Thank you for sending a pull request! Please make sure:

1. Your PR fixes a referenced issue, please create one if no issue applies to your PR.
2. The issue number is referenced in the branch name.
3. You follow the contributing rules at: https://github.com/TOSIT-IO/tdp-collection/blob/master/docs/contributing.md.
-->

#### Which issue(s) this PR fixes:
<!--
Example: "Fixes #(issue number)" or "Fixes (link of issue)".
-->
Fixes #20 

#### Additional comments:
<!--
Example: `"I was not sure if it is the right way to do but..."
-->

To make clear that you license your contribution under
the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0) and that you give permission to [TOSIT](https://www.tosit.io/),
you have to acknowledge this by using the following check-box.

 - [x] I hereby declare this contribution to be licenced under the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)

 - [x] I hereby agree to grant [TOSIT](https://www.tosit.io/) a copyright license to use my contributions.


