### PR TITLE
fix: add nmap-ncat package to provide ncat command

### DIFF
--- a/roles/system/defaults/main.yml
+++ b/roles/system/defaults/main.yml
@@ -35,3 +35,4 @@ default_packages:
     - authselect
     - python2
     - python3-cryptography
+    - nmap-ncat

--- a/roles/system/defaults/main.yml
+++ b/roles/system/defaults/main.yml
@@ -18,7 +18,7 @@ default_packages:
     - wget
     - curl
     - unzip
-    - nc
+    - nmap-ncat
     - expect
     - python3
     - python3-pip
@@ -35,4 +35,3 @@ default_packages:
     - authselect
     - python2
     - python3-cryptography
-    - nmap-ncat


### PR DESCRIPTION
ncat command is not installed on RHEL 8.6 and above and needs to be installed separately

<!-- Thank you for sending a pull request! Please make sure:
1. Your PR fixes a referenced issue, please create one if no issue applies to your PR.
2. The issue number is referenced in the branch name.
3. You follow the contributing rules at: https://github.com/TOSIT-IO/tdp-collection/blob/master/docs/contributing.md.
-->

#### Which issue(s) this PR fixes

<!-- Example: "Fixes #(issue number)" or "Fixes (link of issue)". -->

Fixes #55 

#### Additional comments

Possibly also fixe https://github.com/TOSIT-IO/tdp-collection/issues/600



#### Agreements

<!-- To make clear that you license your contribution under the Apache License Version 2.0, January 2004 (http://www.apache.org/licenses/LICENSE-2.0) and that you give permission to TOSIT (https://www.tosit.io/), you have to acknowledge this by using the following check-box. -->

- [x] I hereby declare this contribution to be licensed under the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0).
- [x] I hereby agree to grant [TOSIT](https://www.tosit.io/) a copyright license to use my contributions.
