### PR TITLE
postgres: fix to force to install libpq5 package for python2-psycopg2 on CentOS 7

### DIFF
--- a/roles/postgresql/defaults/main.yml
+++ b/roles/postgresql/defaults/main.yml
@@ -26,6 +26,7 @@ postgresql_default_packages:
 postgresql_client_default_packages:
   legacy: # centos 7 and below
     - python2-psycopg2
+    - libpq5
   modern: # centos 8 and above
     - python3-psycopg2
 


### PR DESCRIPTION
<!-- Thank you for sending a pull request! Please make sure:
1. Your PR fixes a referenced issue, please create one if no issue applies to your PR.
2. The issue number is referenced in the branch name.
3. You follow the contributing rules at: https://github.com/TOSIT-IO/tdp-collection/blob/master/docs/contributing.md.
-->

#### Which issue(s) this PR fixes

<!-- Example: "Fixes #(issue number)" or "Fixes (link of issue)". -->

Fixes #64

#### Additional comments

<!-- Example: "I was not sure if it is the right way to do but..." -->

Installation of ```libpq5``` package needs to enable EPEL repository on CentOS 7.

#### Agreements

<!-- To make clear that you license your contribution under the Apache License Version 2.0, January 2004 (http://www.apache.org/licenses/LICENSE-2.0) and that you give permission to TOSIT (https://www.tosit.io/), you have to acknowledge this by using the following check-box. -->

- [ ] I hereby declare this contribution to be licensed under the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0).
- [ ] I hereby agree to grant [TOSIT](https://www.tosit.io/) a copyright license to use my contributions.
