### PR TITLE
fix(ldap): hide secrets when creating LDAP groups

### DIFF
--- a/roles/ldap_kerberos/tasks/install_openldap_server.yml
+++ b/roles/ldap_kerberos/tasks/install_openldap_server.yml
@@ -92,6 +92,10 @@
     - reg_ldapadd.rc != 68
   changed_when: reg_ldapadd.rc != 68
   loop: "{{ ldap_groups }}"
+  loop_control:
+    label:
+      group: "{{ item.group }}"
+      gid: "{{ item.gid }}"
   vars:
     group: "{{ item.group }}"
     gid: "{{ item.gid }}"


### PR DESCRIPTION
<!-- Thank you for sending a pull request! Please make sure:
1. Your PR fixes a referenced issue, please create one if no issue applies to your PR.
2. The issue number is referenced in the branch name.
3. You follow the contributing rules at: https://github.com/TOSIT-IO/tdp-collection/blob/master/docs/contributing.md.
-->

#### Which issue(s) this PR fixes

<!-- Example: "Fixes #(issue number)" or "Fixes (link of issue)". -->

Fixes #38 

#### Additional comments

<!-- Example: "I was not sure if it is the right way to do but..." -->
Do not display passwords in Ansible logs when creating LDAP groups.  
Before :
```
TASK [tosit.tdp_prerequisites.ldap_kerberos : Create LDAP groups] **************
ok: [bdpnode01] => (item={'user': 'user1', 'password': 'secret', 'group': 'group1', 'uid': 1101, 'gid': 1020})
ok: [bdpnode01] => (item={'user': 'user2', 'password': 'secret', 'group': 'group2', 'uid': 1102, 'gid': 1021})
```
After :
```
TASK [tosit.tdp_prerequisites.ldap_kerberos : Create LDAP groups] ********************************************************************************
ok: [bdpnode01] => (item={'group': 'group1', 'gid': '1020'})
ok: [bdpnode01] => (item={'group': 'group2', 'gid': '1021'})
```

#### Agreements

<!-- To make clear that you license your contribution under the Apache License Version 2.0, January 2004 (http://www.apache.org/licenses/LICENSE-2.0) and that you give permission to TOSIT (https://www.tosit.io/), you have to acknowledge this by using the following check-box. -->

- [x] I hereby declare this contribution to be licensed under the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0).
- [x] I hereby agree to grant [TOSIT](https://www.tosit.io/) a copyright license to use my contributions.
