### PR TITLE
fix: set alternatives to python3 for RHEL8

### DIFF
--- a/roles/system/tasks/python_pip.yml
+++ b/roles/system/tasks/python_pip.yml
@@ -20,3 +20,10 @@
     state: latest
     executable: pip3
   environment: "{{ proxy_env }}"
+
+# https://developers.redhat.com/blog/2019/05/07/what-no-python-in-red-hat-enterprise-linux-8
+- name: Set alternatives for Rocky8
+  alternatives:
+    name: python
+    path: /usr/bin/python3
+  when: ansible_distribution_major_version | int > 7


### PR DESCRIPTION
<!-- Thank you for sending a pull request! Please make sure:
1. Your PR fixes a referenced issue, please create one if no issue applies to your PR.
2. The issue number is referenced in the branch name.
3. You follow the contributing rules at: https://github.com/TOSIT-IO/tdp-collection/blob/master/docs/contributing.md.
-->

#### Which issue(s) this PR fixes

<!-- Example: "Fixes #(issue number)" or "Fixes (link of issue)". -->

Fixes #75 

#### Additional comments

<!-- Example: "I was not sure if it is the right way to do but..." -->

This change raises an issue when running ansible up to 2.12.

```
[DEPRECATION WARNING]: Distribution centos 8.7 on host edge-01 should use /usr/libexec/platform-python, but is using /usr/bin/python for backward compatibility with prior Ansible releases. A future Ansible release will default to using the discovered platform python for this host. See 
https://docs.ansible.com/ansible/2.9/reference_appendices/interpreter_discovery.html for more information. This feature will be removed in version 2.12. Deprecation warnings can be disabled by setting deprecation_warnings=False in ansible.cfg.
```

I think we should specify somewhere to use `ansible_python_interpreter=auto` . I think its location is in the `ansible.cfg` in getting-started

#### Agreements

<!-- To make clear that you license your contribution under the Apache License Version 2.0, January 2004 (http://www.apache.org/licenses/LICENSE-2.0) and that you give permission to TOSIT (https://www.tosit.io/), you have to acknowledge this by using the following check-box. -->

- [x] I hereby declare this contribution to be licensed under the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0).
- [x] I hereby agree to grant [TOSIT](https://www.tosit.io/) a copyright license to use my contributions.
