### PR TITLE
fix: cgred update for rhel8

### DIFF
--- a/roles/system/tasks/cgroups.yml
+++ b/roles/system/tasks/cgroups.yml
@@ -13,3 +13,4 @@
     name: cgred
     state: started
     enabled: yes
+  when: ansible_distribution_major_version | int < 8


### PR DESCRIPTION
<!-- Thank you for sending a pull request! Please make sure:
1. Your PR fixes a referenced issue, please create one if no issue applies to your PR.
2. The issue number is referenced in the branch name.
3. You follow the contributing rules at: https://github.com/TOSIT-IO/tdp-collection/blob/master/docs/contributing.md.
-->

#### Which issue(s) this PR fixes

<!-- Example: "Fixes #(issue number)" or "Fixes (link of issue)". -->

Fixes #71 

#### Additional comments

`cgrep` has been depreciated in favor of systemd for rhel8 or any 8.x derivative `rpm -q --changelog libcgroup.` :
```
Tue Jan 14 2014 … 0.41-1

    resolves: #966008
    updated to 0.41
    removed deprecated cgred service
    please use Control Group Interface in Systemd instead

```

source: http://rpmfind.net/linux/RPM/centos/8-stream/baseos/x86_64/Packages/libcgroup-0.41-19.el8.x86_64.html

#### Agreements

<!-- To make clear that you license your contribution under the Apache License Version 2.0, January 2004 (http://www.apache.org/licenses/LICENSE-2.0) and that you give permission to TOSIT (https://www.tosit.io/), you have to acknowledge this by using the following check-box. -->

- [x] I hereby declare this contribution to be licensed under the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0).
- [x] I hereby agree to grant [TOSIT](https://www.tosit.io/) a copyright license to use my contributions.
