### PR TITLE
feat(certificates): use "$PWD/files" for certificates local path

### DIFF
--- a/roles/certificates/defaults/main.yml
+++ b/roles/certificates/defaults/main.yml
@@ -3,6 +3,7 @@
 
 ---
 certificates_path: /etc/ssl/certs
+certificates_local_path: "{{ lookup('env', 'PWD') }}/files"
 certificates_country_name: fr
 certificates_organization_name: TDP
 certificates_cluster_name: tdp_getting_started

--- a/roles/certificates/files/.gitignore
+++ b/roles/certificates/files/.gitignore
@@ -1,2 +1,0 @@
-*
-!.gitignore

--- a/roles/certificates/tasks/copy_to_host.yml
+++ b/roles/certificates/tasks/copy_to_host.yml
@@ -5,7 +5,7 @@
 - name: Copy certificate authority certificate to host
   diff: no
   ansible.builtin.copy:
-    src: "{{ role_path }}/files/{{ certificates_cluster_name }}_certs/{{ certificates_ca_filename }}.crt"
+    src: "{{ certificates_local_path }}/{{ certificates_cluster_name }}_certs/{{ certificates_ca_filename }}.crt"
     dest: "{{ certificates_path }}/{{ certificates_ca_filename }}.crt"
     mode: "644"
 
@@ -24,7 +24,7 @@
 - name: Copy certificate to host
   diff: no
   ansible.builtin.copy:
-    src: "{{ role_path }}/files/{{ certificates_cluster_name }}_certs/{{ certificates_cert_filename }}.pem"
+    src: "{{ certificates_local_path }}/{{ certificates_cluster_name }}_certs/{{ certificates_cert_filename }}.pem"
     dest: "{{ certificates_path }}"
 
 - name: Getting content of certificate and private key 

--- a/roles/certificates/tasks/generate_certificate_authority.yml
+++ b/roles/certificates/tasks/generate_certificate_authority.yml
@@ -36,5 +36,5 @@
 - name: Fetch certificate authority's certificate
   ansible.builtin.fetch:
     src: "{{ certificates_path }}/{{ certificates_ca_filename }}.crt"
-    dest: "{{ role_path }}/files/{{ certificates_cluster_name }}_certs/"
+    dest: "{{ certificates_local_path }}/{{ certificates_cluster_name }}_certs/"
     flat: yes

--- a/roles/certificates/tasks/generate_host_csr.yml
+++ b/roles/certificates/tasks/generate_host_csr.yml
@@ -23,11 +23,11 @@
   delegate_to: localhost
   become: no
   ansible.builtin.file:
-    path: "{{ role_path }}/files/{{ certificates_cluster_name }}_certs"
+    path: "{{ certificates_local_path }}/{{ certificates_cluster_name }}_certs"
     state: directory
 
 - name: Fetch host's certificate signing request
   ansible.builtin.fetch:
     src: "{{ certificates_path }}/{{ certificates_cert_filename }}.csr"
-    dest: "{{ role_path }}/files/{{ certificates_cluster_name }}_certs/"
+    dest: "{{ certificates_local_path }}/{{ certificates_cluster_name }}_certs/"
     flat: yes

--- a/roles/certificates/tasks/sign_certificates.yml
+++ b/roles/certificates/tasks/sign_certificates.yml
@@ -9,7 +9,7 @@
 
 - name: Send host's CSR to CA machine
   ansible.builtin.copy:
-    src: "{{ role_path }}/files/{{ certificates_cluster_name }}_certs/{{ certificates_cert_filename }}.csr"
+    src: "{{ certificates_local_path }}/{{ certificates_cluster_name }}_certs/{{ certificates_cert_filename }}.csr"
     dest: "{{ certificates_path }}/{{ certificates_cluster_name }}_certs/"
 
 - name: Generate {{ certificates_cert_filename }} certificate
@@ -23,5 +23,5 @@
 - name: Fetch host's signed certificate
   ansible.builtin.fetch:
     src: "{{ certificates_path }}/{{ certificates_cluster_name }}_certs/{{ certificates_cert_filename }}.pem"
-    dest: "{{ role_path }}/files/{{ certificates_cluster_name }}_certs/"
+    dest: "{{ certificates_local_path }}/{{ certificates_cluster_name }}_certs/"
     flat: yes


### PR DESCRIPTION
The "files" directory of a role is not intended to store generated certificates.

<!-- Thank you for sending a pull request! Please make sure:
1. Your PR fixes a referenced issue, please create one if no issue applies to your PR.
2. The issue number is referenced in the branch name.
3. You follow the contributing rules at: https://github.com/TOSIT-IO/tdp-collection/blob/master/docs/contributing.md.
-->

#### Which issue(s) this PR fixes

<!-- Example: "Fixes #(issue number)" or "Fixes (link of issue)". -->

Fixes #91 

#### Additional comments

<!-- Example: "I was not sure if it is the right way to do but..." -->



#### Agreements

<!-- To make clear that you license your contribution under the Apache License Version 2.0, January 2004 (http://www.apache.org/licenses/LICENSE-2.0) and that you give permission to TOSIT (https://www.tosit.io/), you have to acknowledge this by using the following check-box. -->

- [x] I hereby declare this contribution to be licensed under the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0).
- [x] I hereby agree to grant [TOSIT](https://www.tosit.io/) a copyright license to use my contributions.
