### PR TITLE
feat: include JDBC connector installation

### DIFF
--- a/roles/postgresql/defaults/main.yml
+++ b/roles/postgresql/defaults/main.yml
@@ -70,6 +70,8 @@ postgresql_additional_settings: []
 
 postgresql_settings: "{{ postgresql_generated_settings + postgresql_additional_settings }}"
 
+postgresql_jdbc_connector_package: postgresql-jdbc
+
 postgresql_rangeradmin_user: rangeradmin
 postgresql_rangeradmin_password: rangeradmin
 postgresql_rangeradmin_database: ranger

--- a/roles/postgresql/tasks/packages_client.yml
+++ b/roles/postgresql/tasks/packages_client.yml
@@ -17,3 +17,8 @@
     state: present
   vars:
     packages_version: "{{ ( (ansible_distribution_major_version | int) < 8) | ternary('legacy','modern') }}"
+
+- name: Install jdbc connector
+  ansible.builtin.package:
+    name: "{{ postgresql_jdbc_connector_package }}"
+    state: present


### PR DESCRIPTION
<!-- Thank you for sending a pull request! Please make sure:
1. Your PR fixes a referenced issue, please create one if no issue applies to your PR.
2. The issue number is referenced in the branch name.
3. You follow the contributing rules at: https://github.com/TOSIT-IO/tdp-collection/blob/master/docs/contributing.md.
-->

#### Which issue(s) this PR fixes

<!-- Example: "Fixes #(issue number)" or "Fixes (link of issue)". -->

Fixes None


#### Additional comments

Before the JDBC connector was installed with the `tdp-collection` notebook, which could cause some problems since the installation manner was different according to the connector whether it was Postgres or MySQL. Now it is handled here in the prerequisites. It is installed in hosts where postgres-client is installed. So it Is additionally installed in the edge node compared to before.

Works with PR [tdp-collection#862](https://github.com/TOSIT-IO/tdp-collection/pull/862).



#### Agreements

<!-- To make clear that you license your contribution under the Apache License Version 2.0, January 2004 (http://www.apache.org/licenses/LICENSE-2.0) and that you give permission to TOSIT (https://www.tosit.io/), you have to acknowledge this by using the following check-box. -->

- [x] I hereby declare this contribution to be licensed under the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0).
- [x] I hereby agree to grant [TOSIT](https://www.tosit.io/) a copyright license to use my contributions.
