### PR TITLE
fix(sssd): use variable for user and group search base

### DIFF
--- a/roles/ldap_kerberos/templates/sssd.conf.j2
+++ b/roles/ldap_kerberos/templates/sssd.conf.j2
@@ -11,8 +11,8 @@ chpass_provider = ldap
 cache_credentials = True
 ldap_uri = ldap://{{ ldap_server }}
 ldap_search_base = {{ ldap_suffix }}
-ldap_user_search_base = ou=users,{{ ldap_suffix }}
-ldap_group_search_base = ou=groups,{{ ldap_suffix }}
+ldap_user_search_base = {{ ldap_users_base }}
+ldap_group_search_base = {{ ldap_groups_base }}
 ldap_default_bind_dn = {{ ldap_admin_dn }}
 ldap_default_authtok = {{ ldap_admin_dn_password }}
 sudo_provider = none


### PR DESCRIPTION
<!-- Thank you for sending a pull request! Please make sure:
1. Your PR fixes a referenced issue, please create one if no issue applies to your PR.
2. The issue number is referenced in the branch name.
3. You follow the contributing rules at: https://github.com/TOSIT-IO/tdp-collection/blob/master/docs/contributing.md.
-->

#### Which issue(s) this PR fixes

<!-- Example: "Fixes #(issue number)" or "Fixes (link of issue)". -->

#### Additional comments

<!-- Example: "I was not sure if it is the right way to do but..." -->

Default variables "ldap_users_base" and "ldap_groups_base" are defined but not used in sssd configuration.

#### Agreements

<!-- To make clear that you license your contribution under the Apache License Version 2.0, January 2004 (http://www.apache.org/licenses/LICENSE-2.0) and that you give permission to TOSIT (https://www.tosit.io/), you have to acknowledge this by using the following check-box. -->

- [x] I hereby declare this contribution to be licensed under the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0).
- [x] I hereby agree to grant [TOSIT](https://www.tosit.io/) a copyright license to use my contributions.
